### PR TITLE
Uses a full Font Stack now

### DIFF
--- a/Assets/Global.css
+++ b/Assets/Global.css
@@ -4,7 +4,8 @@ html, body {
 }
 
 html, body, button, input, select, textarea {
-	font: 14px tahoma;
+	font-size: 14px;
+	font-family: Tahoma,Verdana,Segoe,sans-serif;
 }
 
 button, input, select, textarea {


### PR DESCRIPTION
Tahoma is not available on most systems that
are not Windows, so a full Font Stack is needed
to make sure similar fonts are used on other
systems.
